### PR TITLE
Remove 'publisher' from sign up page

### DIFF
--- a/app/views/publishers/registrations/new.html.erb
+++ b/app/views/publishers/registrations/new.html.erb
@@ -2,7 +2,7 @@
   <div class="row">
     <div class="col-lg-4 mx-auto mt-2">
       <div class="text-center mb-4">
-        <h2>Sign up as a publisher</h2>
+        <h2>Sign up</h2>
         or
         <%= link_to 'sign in to your account',
                     new_session_path(resource_name) %>


### PR DESCRIPTION
This is so users will not be confused but the kind of people we expect to use the app.