### PR TITLE
Move published request for tenders to publish request for tenders column

### DIFF
--- a/app/controllers/request_for_tenders/build_controller.rb
+++ b/app/controllers/request_for_tenders/build_controller.rb
@@ -75,8 +75,10 @@ class RequestForTenders::BuildController < PublishersController
     request_for_tender.status = :active
     request_for_tender.update_attributes(request_for_tender_params)
     redirect_to publisher_root_path,
-                  notice: 'Your request for tender has been published' \
-                          'successfully'
+                  notice: "Your request for tender has been published. Share " \
+                          "this link "\
+                          "https://public.tenderswift.com/#{request_for_tender.id} " \
+                          "with anyone you wish to submit a bid for this request"
   end
 
   def submit_the_request_for_tender(request_for_tender)

--- a/spec/features/publisher/6_add_tender_distribution_information_spec.rb
+++ b/spec/features/publisher/6_add_tender_distribution_information_spec.rb
@@ -56,8 +56,10 @@ def when_they_publish_a_request_for_tender(request_for_tender)
     click_button 'Publish'
   end
 
-  expect(page).to have_content 'Your request for tender has been published' \
-                               'successfully'
+  expect(page).to have_content "Your request for tender has been published. Share " \
+                                "this link "\
+                                "https://public.tenderswift.com/#{request_for_tender.id} " \
+                                "with anyone you wish to submit a bid for this request"
 end
 
 def and_the_request_for_tender_should_have_a_purchase_tender_page(


### PR DESCRIPTION
Published request for tenders were not showing under the published column
on the dashboard